### PR TITLE
Set FileID on Cloudflare upload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,8 @@ function upload(config, file) {
   return axios.post(
     `https://api.cloudflare.com/client/v4/accounts/${config.accountId}/images/v1`,
     {
-      file: file.stream || file.buffer
+      file: file.stream || file.buffer,
+      id: file.hash
     }, {
       headers: {
         Authorization: `Bearer ${config.apiKey}`,


### PR DESCRIPTION
Fixes [https://github.com/sanjay-io/strapi-provider-upload-cloudflare/issues/3](https://github.com/sanjay-io/strapi-provider-upload-cloudflare/issues/3)

Cloudflare supports custom IDs (so the ID of the URL is meaningful instead of "upload_ba7d23f8ddb581bcb1a9999a99990ff9" like you get now). Strapi supports giving you a hash which can be used.

Cloudinary plugin uses the hash already for this (see https://github.com/strapi/strapi/blob/main/packages/providers/upload-cloudinary/src/index.ts#L34

For docs, see: https://developers.cloudflare.com/images/cloudflare-images/upload-images/custom-id/

